### PR TITLE
Update datacenter.go

### DIFF
--- a/datacenter.go
+++ b/datacenter.go
@@ -41,8 +41,8 @@ type DatacenterConfig struct {
 	Latitude                                           float64                `json:"latitude,omitempty" yaml:"latitude,omitempty"`
 	Longitude                                          float64                `json:"longitude,omitempty" yaml:"longitude,omitempty"`
 	Address                                            string                 `json:"address,omitempty" yaml:"address,omitempty"`
-	ServerRegisterUsingGeneratedIPMICredentialsEnabled bool                   `json:"serverRegisterUsingGeneratedIPMICredentialsEnabled" yaml:"serverRegisterUsingGeneratedIPMICredentialsEnabled"`
-	ServerRegisterUsingProvidedIPMICredentialsEnabled  bool                   `json:"serverRegisterUsingProvidedIPMICredentialsEnabled" yaml:"serverRegisterUsingProvidedIPMICredentialsEnabled"`
+	ServerRegisterUsingGeneratedIPMICredentialsEnabled bool                   `json:"serverRegisterUsingGeneratedIPMICredentialsEnabled,omitempty" yaml:"serverRegisterUsingGeneratedIPMICredentialsEnabled,omitempty"`
+	ServerRegisterUsingProvidedIPMICredentialsEnabled  bool                   `json:"serverRegisterUsingProvidedIPMICredentialsEnabled,omitempty" yaml:"serverRegisterUsingProvidedIPMICredentialsEnabled,omitempty"`
 	SwitchProvisioner                                  map[string]interface{} `json:"switchProvisioner,omitempty" yaml:"switchProvisioner,omitempty"`
 	EnableTenantAccessToIPMI                           bool                   `json:"enableTenantAccessToIPMI" yaml:"enableTenantAccessToIPMI"`
 	AllowVLANOverrides                                 bool                   `json:"allowVLANOverrides" yaml:"allowVLANOverrides"`


### PR DESCRIPTION
Added omitempty for two datacenter config properties because the "null" values for them was overwriting the default values from the controller.